### PR TITLE
Use warehouse URL prefix for PyPI extlinks

### DIFF
--- a/sphinx_celery/conf.py
+++ b/sphinx_celery/conf.py
@@ -35,7 +35,10 @@ INTERSPHINX_MAPPING = {
     'vine': ('https://vine.readthedocs.io/en/latest/', None),
     'flower': ('https://flower.readthedocs.io/en/latest/', None),
     'redis': ('https://redis-py.readthedocs.io/en/latest/', None),
-    'django': ('http://docs.djangoproject.com/en/dev/', 'https://docs.djangoproject.com/en/dev/_objects'),
+    'django': (
+        'http://docs.djangoproject.com/en/dev/',
+        'https://docs.djangoproject.com/en/dev/_objects',
+    ),
     'boto': ('https://boto.readthedocs.io/en/latest/', None),
     'sqlalchemy': ('https://sqlalchemy.readthedocs.io/en/latest', None),
     'kazoo': ('https://kazoo.readthedocs.io/en/latest/', None),

--- a/sphinx_celery/conf.py
+++ b/sphinx_celery/conf.py
@@ -161,7 +161,7 @@ def build_config(
         'https://github.com/%s/', '@',
     ))
     extlinks.setdefault('pypi', (
-        'https://pypi.python.org/pypi/%s/', '',
+        'https://pypi.org/project/%s/', '',
     ))
     extlinks.setdefault('wikipedia', (
         'https://en.wikipedia.org/wiki/%s', '',


### PR DESCRIPTION
This saves one unnecessary redirect from ``pypi.python.org/pypi/{NAME}`` to ``pypi.org/project/{NAME}``.