### PR TITLE
Add placeholder to extlinks captions

### DIFF
--- a/sphinx_celery/conf.py
+++ b/sphinx_celery/conf.py
@@ -154,20 +154,20 @@ def build_config(
 
     extlinks.setdefault('sha', (
         f'https://github.com/{github_project}/commit/%s',
-        'GitHub SHA@',
+        'GitHub SHA@%s',
     ))
     extlinks.setdefault('github_branch', (
         f'https://github.com/{github_project}/tree/%s',
-        'GitHub branch',
+        'GitHub branch %s',
     ))
     extlinks.setdefault('github_user', (
-        'https://github.com/%s/', '@',
+        'https://github.com/%s/', '@%s',
     ))
     extlinks.setdefault('pypi', (
-        'https://pypi.org/project/%s/', '',
+        'https://pypi.org/project/%s/', None,
     ))
     extlinks.setdefault('wikipedia', (
-        'https://en.wikipedia.org/wiki/%s', '',
+        'https://en.wikipedia.org/wiki/%s', None,
     ))
 
     if not canonical_dev_url:


### PR DESCRIPTION
This gets rid of the warning `extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'` (and also saves from an error when bumping Sphinx to v6 in the future) and fixes builds with nitpicky mode on, like e.g. [here](https://github.com/celery/django-celery-beat/runs/7668491928?check_suite_focus=true).