### PR TITLE
Update canonical_dev_url

### DIFF
--- a/sphinx_celery/conf.py
+++ b/sphinx_celery/conf.py
@@ -172,7 +172,7 @@ def build_config(
 
     if not canonical_dev_url:
         canonical_dev_url = '/'.join([
-            canonical_url.rstrip('/'), 'en', 'master',
+            canonical_url.rstrip('/'), 'en', 'main',
         ])
     if not canonical_stable_url:
         canonical_stable_url = '/'.join([


### PR DESCRIPTION
- Update the `canonical_dev_url` to use `main` branch instead of `master`.
- Fixes celery/celery#8453