### PR TITLE
Fixed: "Extension error (sphinx.ext.intersphinx)"

### DIFF
--- a/sphinx_celery/conf.py
+++ b/sphinx_celery/conf.py
@@ -38,7 +38,7 @@ INTERSPHINX_MAPPING = {
     'redis': ('https://redis-py.readthedocs.io/en/latest/', None),
     'django': (
         'http://docs.djangoproject.com/en/dev/',
-        'https://docs.djangoproject.com/en/dev/_objects',
+        'https://doc.djangoproject.com/en/dev/_objects',
     ),
     'boto': ('https://boto.readthedocs.io/en/latest/', None),
     'sqlalchemy': ('https://sqlalchemy.readthedocs.io/en/latest', None),
@@ -49,7 +49,7 @@ INTERSPHINX_MAPPING = {
     'eventlet': ('https://eventlet.net/doc/', None),
     'gevent': ('http://www.gevent.org/', None),
     'pyOpenSSL': ('https://pyopenssl.readthedocs.io/en/stable/', None),
-    'pytest': ('https://docs.pytest.org/en/latest/', None),
+    'pytest': ('https://doc.pytest.org/en/latest/', None),
     'tox': ('https://tox.readthedocs.io/en/latest', None),
 }
 


### PR DESCRIPTION
On `master`:
```bash
make -C docs livehtml
sphinx-autobuild -b html --host 0.0.0.0 --port 7010 --watch /docs -c . . _build/html
[sphinx-autobuild] > sphinx-build -b html -c . /Users/nusnus/dev/GitHub/pytest-celery/docs /Users/nusnus/dev/GitHub/pytest-celery/docs/_build/html
Running Sphinx v7.2.6
WARNING: html_static_path entry '_static' does not exist
loading pickled environment... done
loading intersphinx inventory from https://docs.djangoproject.com/en/dev/_objects...
loading intersphinx inventory from https://docs.pytest.org/en/latest/objects.inv...
intersphinx inventory has moved: https://docs.djangoproject.com/en/dev/_objects -> https://docs.djangoproject.com/en/dev/_objects/

Extension error (sphinx.ext.intersphinx):
Handler <function load_mappings at 0x1063ce660> for event 'builder-inited' threw an exception (exception: '<' not supported between instances of 'dict' and 'dict')
Command exited with exit code: 2
The server will continue serving the build folder, but the contents being served are no longer in sync with the documentation sources. Please fix the cause of the error above or press Ctrl+C to stop the server.
[I 240111 16:42:41 server:335] Serving on http://0.0.0.0:7010
[I 240111 16:42:41 handlers:62] Start watching changes
[I 240111 16:42:41 handlers:64] Start detecting changes
^C[I 240111 16:42:44 server:358] Shutting down...
```

With this fix:
```
make -C docs livehtml
sphinx-autobuild -b html --host 0.0.0.0 --port 7010 --watch /docs -c . . _build/html
[sphinx-autobuild] > sphinx-build -b html -c . /Users/nusnus/dev/GitHub/pytest-celery/docs /Users/nusnus/dev/GitHub/pytest-celery/docs/_build/html
Running Sphinx v7.2.6
WARNING: html_static_path entry '_static' does not exist
loading pickled environment... done
loading intersphinx inventory from https://doc.djangoproject.com/en/dev/_objects...
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://doc.djangoproject.com/en/dev/_objects' not fetchable due to <class 'requests.exceptions.ConnectionError'>: HTTPSConnectionPool(host='doc.djangoproject.com', port=443): Max retries exceeded with url: /en/dev/_objects (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x10980b410>: Failed to resolve 'doc.djangoproject.com' ([Errno 8] nodename nor servname provided, or not known)"))
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 0 source files that are out of date
updating environment: [config changed ('intersphinx_mapping')] 9 added, 0 changed, 0 removed
reading sources... [100%] userguide/tbd
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] userguide/tbd
generating indices... genindex done
highlighting module code...
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in _build/html.
[I 240111 16:42:51 server:335] Serving on http://0.0.0.0:7010
[I 240111 16:42:51 handlers:62] Start watching changes
[I 240111 16:42:51 handlers:64] Start detecting changes
```